### PR TITLE
fixed undeclared variable

### DIFF
--- a/app/convert.js
+++ b/app/convert.js
@@ -181,7 +181,7 @@ function Convert() {
 
 		//subcrawling ^ has similar code as * /, so this "subcrawl" function can do them all with callback
 		function subcrawl(arr, signs, callback) {
-			let res = null; let arr2 = []; //current result, new reduced array of Q
+			let i; let res = null; let arr2 = []; //current result, new reduced array of Q
 			for(i = 0; i < arr.length; i += 2) {
 				if(!arr.hasOwnProperty(i+1)) {break;}
 				//is it the sign that we'd like to process right now?


### PR DESCRIPTION
This was causing an error for me. I think that some javascript compilers will sometimes "allow" undeclared variables, so you did not find the error. After I fixed it, my UUC seems to be working normally again. During my fix, I intentionally put the "let i" outside of for(i =...)  because the "i" is used in more than one place of the function, so I wanted to make it clear it is the same "i" for that full function.